### PR TITLE
Allow build environment to be passed as an argument

### DIFF
--- a/lib/commands/commit.js
+++ b/lib/commands/commit.js
@@ -14,6 +14,11 @@ module.exports = {
     type:         String,
     default:      'new gh-pages version',
     description:  'The commit message to include with the build, must be wrapped in quotes.'
+  }, {
+    name:         'environment',
+    type:         String,
+    default:      'production',
+    description:  'The ember environment to create a build for'
   }],
 
   run: function(options, rawArgs) {
@@ -22,7 +27,8 @@ module.exports = {
     var execOptions = { cwd: root };
 
     function buildApp() {
-      return runCommand('ember build --environment=production', execOptions);
+      var env = options.environment;
+      return runCommand('ember build --environment=' + env, execOptions);
     }
 
     function checkoutGhPages() {


### PR DESCRIPTION
Example

````
ember github-pages:commit --message "Initial gh-pages release" --environment development
````