### PR TITLE
Add function to return to last checked out branch/tag

### DIFF
--- a/lib/commands/commit.js
+++ b/lib/commands/commit.js
@@ -48,12 +48,21 @@ module.exports = {
       return runCommand('git add . && git commit -m "' + options.message + '"', execOptions)
     }
 
+    function returnToPreviousCheckout() {
+      // Each '\' needed to be escaped here
+      return runCommand("git checkout `git reflog HEAD | sed -n " +
+        "'/checkout/ !d; s/.* \\(\\S*\\)$/\\1/;p' | sed '2 !d'`", execOptions);
+    }
+
     return buildApp()
       .then(checkoutGhPages)
       .then(copy)
-      .then(addAndCommit).then(function() {
+      .then(addAndCommit)
+      .then(returnToPreviousCheckout)
+      .then(function() {
         var branch = options.branch;
-        ui.write('Done. All that\'s left is to git push the ' + branch + ' branch.\n');
+        ui.write('Done. All that\'s left is to git push the ' + branch +
+          ' branch.\nEx: git push origin ' + branch + '\n');
       });
   }
 };


### PR DESCRIPTION
Used double quotes instead of single to avoid escaping single quotes in shell command

This returns to the last checkout after committing the build files to gh-pages. 

This would break scripts that are using `git push` assuming they're still in the gh-pages branch. 
