### PR TITLE
Update README branch create command for safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Commit these changes `git add -A && git commit -m "Added ember-cli-github-pages 
 Then you need to create the gh-pages branch and remove the unnecessary files:
 
 ```sh
-git checkout --orphan gh-pages && rm -rf `ls -a | grep -vE '\.gitignore|\.git|node_modules|bower_components|(^[.]{1,2}$)'` && git add -A && git commit -m "initial gh-pages commit"
+git checkout --orphan gh-pages && rm -rf `ls -a | grep -vE '\.gitignore|\.git|node_modules|bower_components|(^[.]{1,2}/?$)'` && git add -A && git commit -m "initial gh-pages commit"
 ```
 
 ## Usage


### PR DESCRIPTION
Small change to the gh-pages branch create command to not delete '.' & '..' when `ls`
is aliased to `ls -F`.