### PR TITLE
Auto update dummy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,14 @@ First you need to install ember-cli-github-pages:
 ember install ember-cli-github-pages
 ```
 
-In order to have any assets you have in your repo load correctly you need to add the following to your `tests/dummy/config/environment.js` file:
-```javascript
-if (environment === 'production') {
-  ENV.baseURL = '/name-of-your-repo'
-}
+Upon install, this addon will modify your 'tests/dummy/config/environment.js'.
+Commit these changes with the following command:
+
+```sh
+git add -A && git commit -m "Added ember-cli-github-pages addon"
 ```
 
-Commit these changes `git add -A && git commit -m "Added ember-cli-github-pages addon"`
-
-Then you need to create the gh-pages branch and remove the unnecessary files:
+Then you need to create the `gh-pages` branch and remove the unnecessary files:
 
 ```sh
 git checkout --orphan gh-pages && rm -rf `ls -a | grep -vE '\.gitignore|\.git|node_modules|bower_components|(^[.]{1,2}/?$)'` && git add -A && git commit -m "initial gh-pages commit"

--- a/blueprints/ember-cli-github-pages/index.js
+++ b/blueprints/ember-cli-github-pages/index.js
@@ -6,34 +6,28 @@ var fs        = require('fs');
 var writeFile = RSVP.denodeify(fs.writeFile);
 
 module.exports = {
-  description: 'Updates baseURL in config to work on gh-pages',
+  description: 'Updates baseURL in dummy config to work on gh-pages',
   normalizeEntityName: function() { },
 
   afterInstall: function() {
-    return this.updateBaseURL().then(function() {
-      return this.updateLocationType();
-    }.bind(this)).then(function() {
+    return this.updateDummyConfig().then(function() {
       this.ui.writeLine('Updated config/environment.js baseURL and locationType.');
     }.bind(this));
   },
 
-  updateLocationType: function() {
-    var search  = "locationType: 'auto'";
-    var replace = "locationType: 'hash'";
-
-    return this.replaceEnvironment(search, replace);
-  },
-
-  updateBaseURL: function() {
-    var name    = this.project.config('production').modulePrefix;
-    var search  = "baseURL: '/'";
-    var replace = "baseURL: '/" + name + "'";
+  updateDummyConfig: function() {
+    var name = this.project.pkg.name;
+    var search = "  if (environment === 'production') {";
+    var replace = "  if (environment === 'production') {\n    ENV.locationType = 'hash';\n    ENV.baseURL = '/" + name + "';";
 
     return this.replaceEnvironment(search, replace);
   },
 
   replaceEnvironment: function(search, replace) {
-    return this.replaceInFile('config/environment.js', search, replace);
+    var addon = this.project.pkg['ember-addon'];
+    var configPath = addon ? addon.configPath : 'config';
+
+    return this.replaceInFile(configPath + '/environment.js', search, replace);
   },
 
   replaceInFile: function(pathRelativeToProjectRoot, searchTerm, contentsToInsert) {


### PR DESCRIPTION
So previously this addon was supposed to auto update the config, but it never did since the config is in `tests/dummy/config`.

This change uses the configPath in the package.json to update the correct config.
Not sure if this would require a major bump, since maybe the config was in the base directory before.

See #12 