### PR TITLE
Postfix baseURL with /

### DIFF
--- a/blueprints/ember-cli-github-pages/index.js
+++ b/blueprints/ember-cli-github-pages/index.js
@@ -18,7 +18,7 @@ module.exports = {
   updateDummyConfig: function() {
     var name = this.project.pkg.name;
     var search = "  if (environment === 'production') {";
-    var replace = "  if (environment === 'production') {\n    ENV.locationType = 'hash';\n    ENV.baseURL = '/" + name + "';";
+    var replace = "  if (environment === 'production') {\n    ENV.locationType = 'hash';\n    ENV.baseURL = '/" + name + "/';";
 
     return this.replaceEnvironment(search, replace);
   },


### PR DESCRIPTION
After deploying a couple projects, it looks like the last `/` was required.

Without it, going to `user.github.io/project` resulted in a 404 but going to `user.github.io/project/` worked. This solved that issue for me.