### PR TITLE
Add `destination "directory_name"` option.

### DIFF
--- a/lib/commands/commit.js
+++ b/lib/commands/commit.js
@@ -47,14 +47,19 @@ module.exports = {
 
     function copy() {
       if (options.destination === '.') {
-        return runCommand(`cp -R dist/* .`, execOptions);
+        return runCommand('cp -R dist/* .', execOptions);
       } else {
-        return runCommand(`rm -r ${options.destination} && mkdir ${options.destination} && cp -R dist/* ${options.destination}/`, execOptions);
+        return runCommand('rm -r ' + options.destination +
+                          ' && mkdir ' + options.destination +
+                          ' && cp -R dist/* ' + options.destination + '/',
+                          execOptions);
       }
     }
 
     function addAndCommit() {
-      return runCommand(`git -c core.safecrlf=false add "${options.destination}" && git commit -m "${options.message}"`, execOptions)
+      return runCommand('git -c core.safecrlf=false add "' + options.destination + '"' +
+                        ' && git commit -m "' + options.message + '"',
+                        execOptions);
     }
 
     function returnToPreviousCheckout() {

--- a/lib/commands/commit.js
+++ b/lib/commands/commit.js
@@ -24,6 +24,11 @@ module.exports = {
     type:         String,
     default:      'gh-pages',
     description:  'The git branch to push your pages to'
+  }, {
+    name:         'destination',
+    type:         String,
+    default:      '.',
+    description:  'The directory into which the built application should be copied'
   }],
 
   run: function(options, rawArgs) {
@@ -41,11 +46,15 @@ module.exports = {
     }
 
     function copy() {
-      return runCommand('cp -R dist/* .', execOptions);
+      if (options.destination === '.') {
+        return runCommand(`cp -R dist/* .`, execOptions);
+      } else {
+        return runCommand(`rm -r ${options.destination} && mkdir ${options.destination} && cp -R dist/* ${options.destination}/`, execOptions);
+      }
     }
 
     function addAndCommit() {
-      return runCommand('git add . && git commit -m "' + options.message + '"', execOptions)
+      return runCommand(`git -c core.safecrlf=false add "${options.destination}" && git commit -m "${options.message}"`, execOptions)
     }
 
     function returnToPreviousCheckout() {


### PR DESCRIPTION
Over at `ember-paper`, we are using your excellent add-on to build two different branches into two different dummy apps. Having this destination option will make it easy for us to continue to use the workflow you created. Thanks for the consideration.

Note: I had some difficulty getting this to work with both Windows and Linux. Testing on mac and linux would be awesome, as I tested only on windows. It is a touch difficult since windows runs the commands with `cmd.exe`, not bash.