### PR TITLE
Updates setup instructions to add .gitkeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ git add -A && git commit -m "Added ember-cli-github-pages addon"
 Then you need to create the `gh-pages` branch and remove the unnecessary files:
 
 ```sh
-git checkout --orphan gh-pages && rm -rf `bash -c "ls -a | grep -vE '\.gitignore|\.git|node_modules|bower_components|(^[.]{1,2}/?$)'"` && git add -A && git commit -m "initial gh-pages commit"
+git checkout --orphan gh-pages && rm -rf `bash -c "ls -a | grep -vE '\.gitignore|\.git|node_modules|bower_components|(^[.]{1,2}/?$)'"` && touch .gitkeep && git add -A && git commit -m "initial gh-pages commit"
 ```
 
 ## Usage


### PR DESCRIPTION
Fixes: https://github.com/poetic/ember-cli-github-pages/issues/37

The `rm -rf` removes everything from the new orphan branch, so when you run `git add -A` there are no files to stage and subsequently nothing to commit which results in `gh-pages` branch not being created at all.

Fixed by creating an empty `.gitkeep`

