### PR TITLE
Remove && operator from chained git commands

### DIFF
--- a/lib/commands/commit.js
+++ b/lib/commands/commit.js
@@ -49,17 +49,21 @@ module.exports = {
       if (options.destination === '.') {
         return runCommand('cp -R dist/* .', execOptions);
       } else {
-        return runCommand('rm -r ' + options.destination +
-                          ' && mkdir ' + options.destination +
-                          ' && cp -R dist/* ' + options.destination + '/',
-                          execOptions);
+        return runCommand('rm -r ' + options.destination, execOptions)
+                .then(function() {
+                  return runCommand('mkdir ' + options.destination, execOptions);
+                })
+                .then(function() {
+                  return runCommand('cp -R dist/* ' + options.destination + '/', execOptions);
+                });
       }
     }
 
     function addAndCommit() {
-      return runCommand('git -c core.safecrlf=false add "' + options.destination + '"' +
-                        ' && git commit -m "' + options.message + '"',
-                        execOptions);
+      return runCommand('git -c core.safecrlf=false add "' + options.destination + '"', execOptions)
+              .then(function() {
+                return runCommand('git commit -m "' + options.message + '"', execOptions);
+              })
     }
 
     function returnToPreviousCheckout() {


### PR DESCRIPTION
Split git commands to multiple calls to `runCommand`. Instead of using the bash operator `&&` to chain multiple git commands, we can chain them by chaining the promises from `runCommand`.

Fixes #64. This prevents the commands from failing when the shell doesn't support `&&`, like in fish. Closes #66, but thanks to them for pointing out the points where it fails.