### PR TITLE
Handle parent directory as destination

### DIFF
--- a/lib/commands/commit.js
+++ b/lib/commands/commit.js
@@ -2,6 +2,7 @@
 
 var exec = require('child_process').exec;
 var RSVP = require('rsvp');
+var path = require('path');
 
 module.exports = {
   name: 'github-pages:commit',
@@ -46,8 +47,9 @@ module.exports = {
     }
 
     function copy() {
-      if (options.destination === '.') {
-        return runCommand('cp -R dist/* .', execOptions);
+      var rel = path.relative(root, options.destination);
+      if (options.destination === '.' || rel.match(/^\.\.(\/\.\.)*$/)) {
+        return runCommand('cp -R dist/* ' + options.destination + '/', execOptions);
       } else {
         return runCommand('rm -r ' + options.destination, execOptions)
                 .then(function() {


### PR DESCRIPTION
I'm open to the suggestion that I'm just doing this wrong :), but: 

The project I'm working with has multiple submodules. One of these modules (two subdirectories deep) we would like to publish with this tool to the gh-pages branch, but to the top-level directory on the gh-pages branch.

E.g.: 
```
ember github-pages:commit --message "Update gh-pages release" --destination ../../
```

This fails in two places: 
* rm -rf ../.. is problematic; 
* mkdir ../.. complains that it's creating a directory that already exists

To fix this I've added a regex that allows this case to be handled by the first condition of the branch.